### PR TITLE
add mac install target 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,16 @@ install: gzlc utilities/gzlparse runtime/libgazelle.a $(INC)
 	install -d $(INCDIR)/gazelle
 	install -m 0644 -o root -g root $(INC) $(INCDIR)/gazelle
 
+#if os is freebsd-like,change "-o root -g root" to "-o root -g wheel"
+macinstall: gzlc utilities/gzlparse runtime/libgazelle.a $(INC)
+	install -d -o root -g wheel $(BINDIR)
+	install -m 0755 -o root -g wheel gzlc $(BINDIR)
+	install -m 0755 -o root -g wheel utilities/gzlparse $(BINDIR)
+	install -d -o root -g wheel $(LIBDIR)
+	install -m 0644 -o root -g wheel runtime/libgazelle.a $(LIBDIR)
+	install -d $(INCDIR)/gazelle
+	install -m 0644 -o root -g wheel $(INC) $(INCDIR)/gazelle
+
 clean:
 	$(RM) $(OBJ)
 	$(RM) $(DEP)

--- a/README
+++ b/README
@@ -29,6 +29,10 @@ To build and install Gazelle, type:
 $ make
 $ make install
 
+if os is freebsd-like,type:
+$ make
+$ make macinstall
+
 You can change the installation location as follows:
 
 $ make PREFIX=/usr/local


### PR DESCRIPTION
if os is freebsd-like,type:
$ make
$ make macinstall
##  # if OS is freebsd-like( for example lion,snow leopard)，before type "make install",we need to modify Makefile，change ”-o root -g root”to ”-o root -g wheel”,or it will show this error:

localhost:gazelle root# make install
make: Circular runtime/Parser.cc <- runtime/Parser.cc dependency dropped.
make: Circular runtime/Grammar.cc <- runtime/Grammar.cc dependency dropped.
install -d -o root -g root /usr/local/bin
install: root: Invalid argument
make: **\* [install] Error 67
